### PR TITLE
Update links.md with Etsy post on Opsweekly

### DIFF
--- a/links.md
+++ b/links.md
@@ -18,6 +18,7 @@ Blog Posts
 - [Communication: Who is to blame for misunderstandings?](http://devops.com/2015/05/12/communication-blame-misunderstandings/)
 - [Social Skills for DevOps: Whose responsibility?](http://devops.com/2015/05/05/social-skills-devops-whose-responsibility/)
 - [How to Work an On Call Job and Keep Your Sanity](http://lifehacker.com/5983847/how-to-work-an-on-call-job-and-keep-your-sanity)
+- [Opsweekly: Measuring on-call experience with alert classification](https://codeascraft.com/2014/06/19/opsweekly-measuring-on-call-experience-with-alert-classification/)
 
 Other projects
 ==============


### PR DESCRIPTION
This article (and tool) by Etsy was the first that I remembered on the subject when I heard about the HumanOps meetup. Hope it's a useful contribution.

> Opsweekly is a weekly report tracker, an on call categorisation and reporting tool, a sleep tracker, a meeting organiser and a coffee maker all in one.
> 
> The goal of Opsweekly is to both organise your team into one central place, but also helps you understand and improve your on call rotations through the use of a simple on call "survey", and reporting as a result of that tracking.
